### PR TITLE
Update README instructions for local usage

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,19 +1,19 @@
 .PHONY: install dev seed retrain test docker
 
 install:
-pip install -e .[dev]
+	pip install -e .[dev]
 
 dev:
-uvicorn autotag.app.main:app --reload
+	uvicorn autotag.app.main:app --reload
 
 seed:
-python -m autotag.scripts.seed_db
+	python -m autotag.scripts.seed_db
 
 retrain:
-python -m autotag.scripts.train_ml
+	python -m autotag.scripts.train_ml
 
 test:
-pytest -q
+	pytest -q
 
 docker:
-docker build -t autotag:dev .
+	docker build -t autotag:dev .


### PR DESCRIPTION
## Summary
- expand the README with clear local, testing, and Docker workflows plus example requests
- document environment assumptions so newcomers know what tools they need
- fix the Makefile recipes to use tabs so the documented make targets work as written

## Testing
- `make test` *(fails: dependencies could not be installed because outbound network access is blocked)*

------
https://chatgpt.com/codex/tasks/task_e_68d14655139883328fd107128ff5af26