### PR TITLE
Add compatibility shims for CLI scripts

### DIFF
--- a/autotag/__init__.py
+++ b/autotag/__init__.py
@@ -1,1 +1,1 @@
-"""AutoTag service package."""
+"""AutoTag service package with compatibility shims for legacy imports."""

--- a/autotag/config.py
+++ b/autotag/config.py
@@ -1,0 +1,7 @@
+"""Backwards-compatible shim for configuration helpers."""
+
+from __future__ import annotations
+
+from .app.config import Settings, get_settings
+
+__all__ = ["Settings", "get_settings"]

--- a/autotag/db.py
+++ b/autotag/db.py
@@ -1,0 +1,7 @@
+"""Backwards-compatible shim for database utilities."""
+
+from __future__ import annotations
+
+from .app.db import Base, SessionLocal, create_all, engine, session_scope
+
+__all__ = ["Base", "SessionLocal", "create_all", "engine", "session_scope"]

--- a/autotag/models.py
+++ b/autotag/models.py
@@ -1,0 +1,7 @@
+"""Backwards-compatible shim for ORM models."""
+
+from __future__ import annotations
+
+from .app.models import Message, TagAudit, Ticket
+
+__all__ = ["Message", "TagAudit", "Ticket"]

--- a/autotag/routers/__init__.py
+++ b/autotag/routers/__init__.py
@@ -1,0 +1,7 @@
+"""Compatibility layer for router modules."""
+
+from __future__ import annotations
+
+from .tagging import router
+
+__all__ = ["router"]

--- a/autotag/routers/tagging.py
+++ b/autotag/routers/tagging.py
@@ -1,0 +1,5 @@
+"""Shim module exposing tagging router utilities."""
+
+from __future__ import annotations
+
+from ..app.routers.tagging import *  # noqa: F401,F403

--- a/autotag/services/__init__.py
+++ b/autotag/services/__init__.py
@@ -1,0 +1,12 @@
+"""Compatibility layer for service helpers."""
+
+from __future__ import annotations
+
+from ..app.services import clarification_bot, confidence_policy, lang_and_scrub, llm_adjudicator
+
+__all__ = [
+    "clarification_bot",
+    "confidence_policy",
+    "lang_and_scrub",
+    "llm_adjudicator",
+]

--- a/autotag/services/clarification_bot.py
+++ b/autotag/services/clarification_bot.py
@@ -1,0 +1,5 @@
+"""Shim for clarification bot service."""
+
+from __future__ import annotations
+
+from ..app.services.clarification_bot import *  # noqa: F401,F403

--- a/autotag/services/confidence_policy.py
+++ b/autotag/services/confidence_policy.py
@@ -1,0 +1,5 @@
+"""Shim for confidence policy helpers."""
+
+from __future__ import annotations
+
+from ..app.services.confidence_policy import *  # noqa: F401,F403

--- a/autotag/services/lang_and_scrub.py
+++ b/autotag/services/lang_and_scrub.py
@@ -1,0 +1,5 @@
+"""Shim for language detection and PII scrubbing helpers."""
+
+from __future__ import annotations
+
+from ..app.services.lang_and_scrub import *  # noqa: F401,F403

--- a/autotag/services/llm_adjudicator.py
+++ b/autotag/services/llm_adjudicator.py
@@ -1,0 +1,5 @@
+"""Shim for LLM adjudicator helpers."""
+
+from __future__ import annotations
+
+from ..app.services.llm_adjudicator import *  # noqa: F401,F403

--- a/autotag/services/ml_classifier.py
+++ b/autotag/services/ml_classifier.py
@@ -1,0 +1,5 @@
+"""Shim for ML classifier helpers."""
+
+from __future__ import annotations
+
+from ..app.services.ml_classifier import *  # noqa: F401,F403

--- a/autotag/services/rules_engine.py
+++ b/autotag/services/rules_engine.py
@@ -1,0 +1,5 @@
+"""Shim for rules engine helpers."""
+
+from __future__ import annotations
+
+from ..app.services.rules_engine import *  # noqa: F401,F403

--- a/autotag/services/tag_writer.py
+++ b/autotag/services/tag_writer.py
@@ -1,0 +1,5 @@
+"""Shim for tag writer helpers."""
+
+from __future__ import annotations
+
+from ..app.services.tag_writer import *  # noqa: F401,F403


### PR DESCRIPTION
## Summary
- add shim modules under `autotag/` to expose configuration, database, models, routers, and services from the `autotag.app` package
- keep the CLI scripts on their original import paths so legacy tooling keeps working

## Testing
- make seed *(fails: missing dependency `pydantic_settings` because packages cannot be installed in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d14a47cb8083328e9858f671bc781e