### PR TITLE
Ensure seed script sets timestamps explicitly

### DIFF
--- a/autotag/scripts/seed_db.py
+++ b/autotag/scripts/seed_db.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 import json
+from datetime import datetime
 
 from ..config import get_settings
 from ..db import create_all, session_scope
@@ -32,14 +33,16 @@ def main() -> None:
 
                 lang = lang_and_scrub.detect_lang(record["text"])
                 clean_text, redactions = lang_and_scrub.scrub_pii(record["text"])
+                message_ts = datetime.utcnow()
                 message = Message(
                     sender="user",
                     text=clean_text,
                     lang=lang,
                     pii_redactions=redactions,
+                    ts=message_ts,
                 )
                 ticket.messages.append(message)
-                ticket.updated_at = message.ts
+                ticket.updated_at = message_ts
                 db.flush()
 
                 conversation_text = " ".join(


### PR DESCRIPTION
## Summary
- explicitly stamp seeded messages with the current UTC timestamp
- apply the same timestamp to the parent ticket to satisfy NOT NULL constraints

## Testing
- `make seed` *(fails: ModuleNotFoundError: No module named 'pydantic_settings' because project dependencies are unavailable)*
- `pip install -e .[dev]` *(fails: build dependencies could not be installed due to proxy restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_68d150177e7c83328713d1172b958814